### PR TITLE
Allow feeding another user

### DIFF
--- a/commands/feed.js
+++ b/commands/feed.js
@@ -1,14 +1,52 @@
 const feedUsers = {
-	"haykam821": "🍗 Master, please take this delicious leg of poultry.",
-	"DamnImLost": "🗺 I think you need a map rather than food.",
-	"BigNig127": "🍎🍏🍎🍏🍎🍏🍎 Take these apples!!!",
-	"blackcats666": "🍒 Lucky you! Have a cherry.",
-	"JaysRooted": "🍕 Have a slice of pizza, even though it's unhealthy.",
+	"haykam821": [
+		"🍗 Master, please take this delicious leg of poultry.",
+		"🍗 403, access to feeding master denied."
+	],
+	"DamnImLost": [
+		"🗺 I think you need a map, not food.",
+		"🗺 I should really get them a map instead of food..."
+	],
+	"BigNig127": [
+		"🍎🍏🍎🍏🍎🍏🍎 Take these apples!!!",
+		"🍎🍏🍎🍏🍎🍏🍎 This user would like you to not go to the doctor ever in your life!!!"
+	],
+	"blackcats666": [
+		"🍒 Lucky you! Have a cherry.",
+		"🍒 Why am I giving a symbol of bad luck a symbol of good luck? It makes no sense!"
+	],
+	"JaysRooted": [
+		"🍕 Have a slice of pizza, even though it's unhealthy.",
+		"🍕 Pizza is great. Yum. Don't eat too much, though."
+	],
 };
-const defaultFeed = "🍎 Have an apple! They keep the doctor away.";
+const defaultFeed = [
+	"🍎 Have an apple! They keep the doctor away.",
+	"🍎 Let's solve world hunger!",
+];
 
 module.exports = {
-	command: "feed",
-	describe: "Feeds you food.",
-	handler: args => args.send(feedUsers[args.author] || defaultFeed),
+	command: "feed [user]",
+	describe: "Feeds you or a specified user food.",
+	builder: build => {
+		build.positional("user", {
+			describe: "The user to feed. If unspecified, feeds you.",
+			type: "string",
+		});
+	},
+	handler: args => {
+		if (args.user === undefined || args.user === args.author) {
+			if (feedUsers[args.author]) {
+				args.send(feedUsers[args.author][0]);
+			} else {
+				args.send(defaultFeed[0]);
+			}
+		} else {
+			if (feedUsers[args.user]) {
+				args.send(feedUsers[args.user][1]);
+			} else {
+				args.send(defaultFeed[1]);
+			}
+		}
+	}
 };


### PR DESCRIPTION
This pull request enables feeding another user with `feed <username>`. If the user is feeding themselves with this functionality, their own feed message will be displayed. A new set of custom messages has been made for feeding someone else.